### PR TITLE
add ability to configure gem

### DIFF
--- a/lib/clarifai_ruby.rb
+++ b/lib/clarifai_ruby.rb
@@ -1,9 +1,26 @@
 require "clarifai_ruby/version"
+require 'clarifai_ruby/configuration'
 require 'httparty'
 
 module ClarifaiRuby
-  # Your code goes here...
-  def self.hello_world
-    "yo, boo"
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configuration=(configuration)
+    @configuration = configuration
+  end
+
+  def self.configure
+    yield configuration
   end
 end
+
+# Usage
+#
+# ClarifaiRuby.configure do |config|
+#   config.base_url = "https://api.clarifai.com/v1"
+#   config.version_path = "/v1"
+#   config.client_id = "XDEWESBGHRDEWFGNBV"
+#   config.client_secret = "-123wedkfjnkj3"
+# end

--- a/lib/clarifai_ruby/configuration.rb
+++ b/lib/clarifai_ruby/configuration.rb
@@ -1,0 +1,14 @@
+module ClarifaiRuby
+  class Configuration
+    attr_accessor :base_url, :client_id, :client_secret, :version_path
+
+    def initialize
+      @base_url = "https://api.clarifai.com"
+      @version_path = "/v1"
+    end
+
+    def api_url
+      base_url + version_path
+    end
+  end
+end

--- a/spec/clarifai_ruby/configuration_spec.rb
+++ b/spec/clarifai_ruby/configuration_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe ClarifaiRuby::Configuration do
+  let(:default_base_url) { "https://api.clarifai.com" }
+  let(:default_version_path) { "/v1" }
+  let(:default_api_url) { "https://api.clarifai.com/v1" }
+
+  describe "#initialize" do
+    it "sets the default base url" do
+      expect(described_class.new.base_url).to eq default_base_url
+    end
+
+    it "sets the default version path" do
+      expect(described_class.new.version_path).to eq default_version_path
+    end
+
+    it "sets a default api url" do
+      expect(described_class.new.api_url).to eq default_api_url
+    end
+  end
+end

--- a/spec/clarifai_ruby_spec.rb
+++ b/spec/clarifai_ruby_spec.rb
@@ -5,7 +5,36 @@ describe ClarifaiRuby do
     expect(ClarifaiRuby::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
-    expect(ClarifaiRuby.hello_world).to eq "yo, boo"
+  describe ".configure" do
+    let(:client_id) { "LukeSkywalker" }
+    let(:client_secret) { "likes_leia" }
+    let(:base_url) { "http://death.star" }
+    let(:version_path) { "/v2" }
+    let(:expected_api_url) { "http://death.star/v2" }
+
+    before do
+      ClarifaiRuby.configure do |config|
+        config.base_url = base_url
+        config.version_path = version_path
+        config.client_id = client_id
+        config.client_secret = client_secret
+      end
+    end
+
+    it "sets the expected api_url" do
+      expect(ClarifaiRuby.configuration.api_url).to eq expected_api_url
+    end
+
+    it "sets the client_id" do
+      expect(ClarifaiRuby.configuration.client_id).to eq client_id
+    end
+
+    it "sets the client_secret" do
+      expect(ClarifaiRuby.configuration.client_secret).to eq client_secret
+    end
+
+    it "sets the version_path" do
+      expect(ClarifaiRuby.configuration.version_path).to eq version_path
+    end
   end
 end


### PR DESCRIPTION
This allows us to configure values for the gem to use later.
Configuration values added were:

```
- client_id
- client_secret
- base_url
- version_path
```

The `api_path` is calculated based on the `base_path` and `version_path`

Now, we can put something like this in an initializer in a Rails application for example:

```
ClarifaiRuby.configure do |config|
   config.base_url = "https://api.clarifai.com/v1"
   config.version_path = "/v1"
   config.client_id = "THISISAN_ID"
   config.client_secret = "-123wedkfjnkj3"
end
```

and when we want to use these configured values in the gem itself:

```
ClarifaiRuby.configuration.client_id #=> will result in the configured value, "THISISAN_ID"
```

Try it out by running `rake console` and manually typing in the config, and seeing that you can access the configured value using `ClarifaiRuby.configuration.whatever_config_value` :D
