### PR TITLE
Feature/info request and response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+

--- a/clarifai_ruby.gemspec
+++ b/clarifai_ruby.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry-byebug", "~> 3.3.0"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "vcr", "~> 3.0.1"
 
   spec.add_runtime_dependency "httparty", "~> 0.13.7"

--- a/lib/clarifai_ruby.rb
+++ b/lib/clarifai_ruby.rb
@@ -3,6 +3,9 @@ require 'httparty'
 require "clarifai_ruby/version"
 require 'clarifai_ruby/configuration'
 require 'clarifai_ruby/client'
+require 'clarifai_ruby/info_request'
+require 'clarifai_ruby/info_response'
+require 'clarifai_ruby/token'
 
 module ClarifaiRuby
   def self.configuration
@@ -16,17 +19,6 @@ module ClarifaiRuby
   def self.configure
     yield configuration
   end
-
-  def self.generate_token
-    body = {
-      "grant_type" => "client_credentials",
-      "client_id" => "#{@configuration.client_id}",
-      "client_secret" => "#{@configuration.client_secret}"
-    }
-
-    response = HTTParty.post(@configuration.api_url + "/token", :body => body).parsed_response
-    @configuration.token = response['access_token']
-  end
 end
 
 # Usage
@@ -34,6 +26,6 @@ end
 # ClarifaiRuby.configure do |config|
 #   config.base_url 			= "https://api.clarifai.com"
 #   config.version_path 	= "/v1"
-#   config.client_id 			= "XDEWESBGHRDEWFGNBV"
-#   config.client_secret 	= "-123wedkfjnkj3"
+#   config.client_id 			=
+#   config.client_secret 	=
 # end

--- a/lib/clarifai_ruby.rb
+++ b/lib/clarifai_ruby.rb
@@ -1,5 +1,6 @@
 require "clarifai_ruby/version"
 require 'clarifai_ruby/configuration'
+require 'clarifai_ruby/client'
 require 'httparty'
 
 module ClarifaiRuby
@@ -14,13 +15,24 @@ module ClarifaiRuby
   def self.configure
     yield configuration
   end
+
+  def self.generate_token
+    body = {
+      "grant_type" => "client_credentials",
+      "client_id" => "#{@configuration.client_id}",
+      "client_secret" => "#{@configuration.client_secret}"
+    }
+
+    response = HTTParty.post(@configuration.api_url + "/token", :body => body).parsed_response
+    @configuration.token = response['access_token']
+  end
 end
 
 # Usage
 #
 # ClarifaiRuby.configure do |config|
-#   config.base_url = "https://api.clarifai.com/v1"
-#   config.version_path = "/v1"
-#   config.client_id = "XDEWESBGHRDEWFGNBV"
-#   config.client_secret = "-123wedkfjnkj3"
+#   config.base_url 			= "https://api.clarifai.com"
+#   config.version_path 	= "/v1"
+#   config.client_id 			= "XDEWESBGHRDEWFGNBV"
+#   config.client_secret 	= "-123wedkfjnkj3"
 # end

--- a/lib/clarifai_ruby.rb
+++ b/lib/clarifai_ruby.rb
@@ -1,7 +1,8 @@
+require 'httparty'
+
 require "clarifai_ruby/version"
 require 'clarifai_ruby/configuration'
 require 'clarifai_ruby/client'
-require 'httparty'
 
 module ClarifaiRuby
   def self.configuration

--- a/lib/clarifai_ruby/client.rb
+++ b/lib/clarifai_ruby/client.rb
@@ -5,11 +5,10 @@ module ClarifaiRuby
     base_uri 'https://api.clarifai.com'
 
     def initialize
-      #get access token with client_id and client_secret & put access token in header
-      @token = Token.new.token
+      #get access token with client_id and client_secret & put access token in heade
       @options = {
         :headers => {
-          "Authorization" => "Bearer #{@token}"
+          "Authorization" => "Bearer #{Token.new.token}"
         }
       }
     end

--- a/lib/clarifai_ruby/client.rb
+++ b/lib/clarifai_ruby/client.rb
@@ -65,19 +65,18 @@ module ClarifaiRuby
     def initialize(options)
       @options = options
       @request_path = '/info'
+      @token = Token.new.token
     end
 
     def get_request_url
       build_request_url
     end
 
-    def get()
-
-      token = get_token
+    def get
       #do the actual GET
       response = self.class.get(build_request_url,
         :headers => {
-          "Authorization" => "Bearer #{token}"
+          "Authorization" => "Bearer #{@token}"
         }
       )
     end
@@ -98,10 +97,6 @@ module ClarifaiRuby
     def build_request_url
       ClarifaiRuby.configuration.api_url + @request_path
     end
-    #
-    def get_token
-      ClarifaiRuby.generate_token
-    end
   end
 end
 
@@ -118,6 +113,25 @@ module ClarifaiRuby
 
     def status_code
       # self.get["status_code"]
+    end
+  end
+end
+
+
+module ClarifaiRuby
+  class Token
+    include HTTParty
+    base_uri 'https://api.clarifai.com'
+
+    attr_reader :token
+
+    def initialize
+      @token = get_token
+    end
+
+    private
+    def get_token
+      ClarifaiRuby.generate_token
     end
   end
 end

--- a/lib/clarifai_ruby/client.rb
+++ b/lib/clarifai_ruby/client.rb
@@ -1,188 +1,30 @@
-
 module ClarifaiRuby
   class Client
     include HTTParty
-    base_uri 'https://api.clarifai.com'
-
-    attr_reader :info_response
-
-    def initialize
-      #get access token with client_id and client_secret & put access token in heade
-      @options = {
-        :headers => {
-          "Authorization" => "Bearer #{Token.new.token}"
-        }
-      }
-    end
-
-    def info
-      info_request = InfoRequest.new(@options)
-      @info_response = InfoResponse.new(info_request.get, 0)
-      # Info.new(opts)
-    end
-
-    # def tag(opts)
-    #   # Tag.new(opts)
-    # end
-    #
-    # def feedback(opts)
-    #   # Feedback.new(opts)
-    # end
-    #
-    # def color(opts)
-    #   # Color.new(opts)
-    # end
-  end
-end
-
-# module ClarifaiRuby
-#   class TagRequest
-#     def initialize
-#
-#     end
-#
-#     def client
-#       ClarifaiRuby.client
-#     end
-#
-#     def get
-#       query = { "url" => img_url }
-#     end
-#
-#   end
-# end
-#
-#
-# ClarifaiRuby::TagRequest.new(image_url, options)
-# # ClarifaiRuby::TagRequest.new(image_url, options)
-# => ClarifaiRuby::TagResponse
-# - tags, probs
-
-
-
-
-
-
-# ClarifaiRuby::InfoRequest.new(options).get
-
-module ClarifaiRuby
-  class InfoRequest
-    include HTTParty
-    base_uri 'https://api.clarifai.com'
-
-    def initialize(options)
-      @options = options
-      @request_path = '/info'
-    end
-
-    def get_request_url
-      build_request_url
-    end
-
-    def get
-      #do the actual GET
-      response = self.class.get(build_request_url, :headers => @options[:headers])
-    end
-    #
-    # def post
-    #   #do the actual POST
-    #   response = #something
-    #   response = JSON.parse(response)
-    #   return ClarifaiRuby::InfoResponse.new(response)
-    # end
-    #
-    # def client
-    #   ClarifaiRuby::Client.new
-    # end
-    #
-    private
-    #
-    def build_request_url
-      ClarifaiRuby.configuration.api_url + @request_path
-    end
-  end
-end
-
-module ClarifaiRuby
-  class InfoResponse #parse the json response anmake it available
-    # attr_reader :max_image_size, :default_model, :max_video_size
-
-    def initialize(json_response, recursion)
-
-      json_response.each do |name, value|
-        if value.is_a? Hash
-          initialize(value, recursion+1)
-        else
-          self.class.send(:attr_reader, name)
-          instance_variable_set("@#{name}", value)
-        end
-      end
-
-
-      # @raw_response = json_response.parsed_response
-      #
-      # print "\n" + @raw_response.to_s + "\n"
-      # @response = @raw_response['results']
-      # print "\n" + @response.to_s + "\n"
-      #
-      # @max_image_size = json_response['results']['max_image_size']
-      # @max_video_size = json_response['results']['max_video_size']
-      # @default_model = json_response['results']['default_model']
-    end
-
-    def status_code
-      # self.get["status_code"]
-    end
-  end
-end
-
-
-module ClarifaiRuby
-  class Token
-    include HTTParty
-    base_uri 'https://api.clarifai.com'
 
     attr_reader :token
 
     def initialize
-      @token = get_token
+      self.class.base_uri ClarifaiRuby.configuration.api_url
+      @token = Token.new.token
+    end
+
+    def get(url, opts={})
+      response = self.class.get(url, headers: auth_header, body: opts)
+      #TODO handle raising any errors here
+    end
+
+    def post(url, opts={})
+      response = self.class.post(url, headers: auth_header, body: opts)
+      #TODO handle raising any errors here
     end
 
     private
-    def get_token
-      ClarifaiRuby.generate_token
+
+    def auth_header
+      {
+        "Authorization" => "Bearer #{token}"
+      }
     end
   end
 end
-
-# ClarifaiRuby::InfoResponse.new(response)
-#
-# ClarifaiRuby::Color.new(image_url, options)
-# - colors
-# ClarifaiRuby::Feedback.new(image_url, options)
-# -
-# ClarifaiRuby::Info.new(image_url, options)
-#
-# ClarifaiRuby::Client.tag(kajsndkajsn,kajsndka)
-# => ClarifaiRuby::Tag.new status_code, status_message, results, tags, probabilities
-
-
-# module ClarifaiRuby
-#   class Model
-#     def status_code
-#
-#     end
-#
-#     def status_message
-#     end
-#
-#     def results
-#     end
-#
-#     def doc_id
-#     end
-#
-#     def meta
-#     end
-#   end
-# end

--- a/lib/clarifai_ruby/client.rb
+++ b/lib/clarifai_ruby/client.rb
@@ -1,0 +1,137 @@
+# module ClarifaiRuby
+#   class Client
+#     include HTTParty
+#     base_uri ClarifaiRuby.configuration.api_url
+#
+#     def initialize
+#       #get access token with client_id and client_secret & put access token in header
+#       @token = Token.new
+#     end
+#
+#     def info(opts)
+#       # Info.new(opts)
+#     end
+#
+#     def tag(opts)
+#       # Tag.new(opts)
+#     end
+#
+#     def feedback(opts)
+#       # Feedback.new(opts)
+#     end
+#
+#     def color(opts)
+#       # Color.new(opts)
+#     end
+#   end
+# end
+
+# module ClarifaiRuby
+#   class TagRequest
+#     def initialize
+#
+#     end
+#
+#     def client
+#       ClarifaiRuby.client
+#     end
+#   end
+# end
+#
+#
+# ClarifaiRuby::TagRequest.new(image_url, options)
+# # ClarifaiRuby::TagRequest.new(image_url, options)
+# => ClarifaiRuby::TagResponse
+# - tags, probs
+
+
+
+
+
+
+# ClarifaiRuby::InfoRequest.new(options).get
+
+module ClarifaiRuby
+  class InfoRequest
+    include httparty
+    base_uri ClarifaiRuby::configuration.api_url
+
+    def initialize(options)
+      @options = options
+      @request_path = "/info"
+    end
+
+    def doc_id
+
+    end
+
+    def get
+      #do the actual GET
+      response = client.get(@request_path, image_url) #something base_uri + request_path
+    end
+
+    def post
+      #do the actual POST
+      response = #something
+      response = JSON.parse(response)
+      return ClarifaiRuby::InfoResponse.new(response)
+    end
+
+    def client
+      ClarifaiRuby::Client.new
+    end
+
+    private
+
+    def build_request_url
+
+    end
+
+    def get_token
+      # go get a token
+    end
+  end
+end
+
+module ClarifaiRuby
+  class InfoResponse #parse the json response and make it available
+    attr_reader :max_image_size
+
+    def initialize(json_response)
+      @raw_response = json_response
+      @max_image_size = json_response['results']['max_image_size']
+    end
+  end
+end
+
+# ClarifaiRuby::InfoResponse.new(response)
+#
+# ClarifaiRuby::Color.new(image_url, options)
+# - colors
+# ClarifaiRuby::Feedback.new(image_url, options)
+# -
+# ClarifaiRuby::Info.new(image_url, options)
+#
+# ClarifaiRuby::Client.tag(kajsndkajsn,kajsndka)
+# => ClarifaiRuby::Tag.new status_code, status_message, results, tags, probabilities
+
+
+# module ClarifaiRuby
+#   class Model
+#     def status_code
+#
+#     end
+#
+#     def status_message
+#     end
+#
+#     def results
+#     end
+#
+#     def doc_id
+#     end
+#
+#     def meta
+#     end
+#   end
+# end

--- a/lib/clarifai_ruby/client.rb
+++ b/lib/clarifai_ruby/client.rb
@@ -4,6 +4,8 @@ module ClarifaiRuby
     include HTTParty
     base_uri 'https://api.clarifai.com'
 
+    attr_reader :info_response
+
     def initialize
       #get access token with client_id and client_secret & put access token in heade
       @options = {
@@ -15,21 +17,21 @@ module ClarifaiRuby
 
     def info
       info_request = InfoRequest.new(@options)
-      info_response = InfoResponse.new(info_request.get)
+      @info_response = InfoResponse.new(info_request.get, 0)
       # Info.new(opts)
     end
 
-    def tag(opts)
-      # Tag.new(opts)
-    end
-
-    def feedback(opts)
-      # Feedback.new(opts)
-    end
-
-    def color(opts)
-      # Color.new(opts)
-    end
+    # def tag(opts)
+    #   # Tag.new(opts)
+    # end
+    #
+    # def feedback(opts)
+    #   # Feedback.new(opts)
+    # end
+    #
+    # def color(opts)
+    #   # Color.new(opts)
+    # end
   end
 end
 
@@ -103,13 +105,29 @@ end
 
 module ClarifaiRuby
   class InfoResponse #parse the json response anmake it available
-    attr_reader :max_image_size, :default_model, :max_video_size
+    # attr_reader :max_image_size, :default_model, :max_video_size
 
-    def initialize(json_response)
-      @raw_response = json_response
-      @max_image_size = json_response['results']['max_image_size']
-      @max_video_size = json_response['results']['max_video_size']
-      @default_model = json_response['results']['default_model']
+    def initialize(json_response, recursion)
+
+      json_response.each do |name, value|
+        if value.is_a? Hash
+          initialize(value, recursion+1)
+        else
+          self.class.send(:attr_reader, name)
+          instance_variable_set("@#{name}", value)
+        end
+      end
+
+
+      # @raw_response = json_response.parsed_response
+      #
+      # print "\n" + @raw_response.to_s + "\n"
+      # @response = @raw_response['results']
+      # print "\n" + @response.to_s + "\n"
+      #
+      # @max_image_size = json_response['results']['max_image_size']
+      # @max_video_size = json_response['results']['max_video_size']
+      # @default_model = json_response['results']['default_model']
     end
 
     def status_code

--- a/lib/clarifai_ruby/client.rb
+++ b/lib/clarifai_ruby/client.rb
@@ -1,3 +1,4 @@
+
 # module ClarifaiRuby
 #   class Client
 #     include HTTParty
@@ -35,6 +36,11 @@
 #     def client
 #       ClarifaiRuby.client
 #     end
+#
+#     def get
+#       query = { "url" => img_url }
+#     end
+#
 #   end
 # end
 #
@@ -53,53 +59,65 @@
 
 module ClarifaiRuby
   class InfoRequest
-    include httparty
-    base_uri ClarifaiRuby::configuration.api_url
+    include HTTParty
+    base_uri 'https://api.clarifai.com'
 
     def initialize(options)
       @options = options
-      @request_path = "/info"
+      @request_path = '/info'
     end
 
-    def doc_id
-
+    def get_request_url
+      build_request_url
     end
 
-    def get
+    def get()
+
+      token = get_token
       #do the actual GET
-      response = client.get(@request_path, image_url) #something base_uri + request_path
+      response = self.class.get(build_request_url,
+        :headers => {
+          "Authorization" => "Bearer #{token}"
+        }
+      )
     end
-
-    def post
-      #do the actual POST
-      response = #something
-      response = JSON.parse(response)
-      return ClarifaiRuby::InfoResponse.new(response)
-    end
-
-    def client
-      ClarifaiRuby::Client.new
-    end
-
+    #
+    # def post
+    #   #do the actual POST
+    #   response = #something
+    #   response = JSON.parse(response)
+    #   return ClarifaiRuby::InfoResponse.new(response)
+    # end
+    #
+    # def client
+    #   ClarifaiRuby::Client.new
+    # end
+    #
     private
-
+    #
     def build_request_url
-
+      ClarifaiRuby.configuration.api_url + @request_path
     end
-
+    #
     def get_token
-      # go get a token
+      ClarifaiRuby.generate_token
     end
   end
 end
 
 module ClarifaiRuby
-  class InfoResponse #parse the json response and make it available
-    attr_reader :max_image_size
+  class InfoResponse #parse the json response anmake it available
+    attr_reader :max_image_size, :default_model, :max_video_size
 
     def initialize(json_response)
       @raw_response = json_response
       @max_image_size = json_response['results']['max_image_size']
+      @max_video_size = json_response['results']['max_video_size']
+      @default_model = json_response['results']['default_model']
+    end
+
+    def status_code
+      # self.get["status_code"]
     end
   end
 end

--- a/lib/clarifai_ruby/client.rb
+++ b/lib/clarifai_ruby/client.rb
@@ -1,31 +1,38 @@
 
-# module ClarifaiRuby
-#   class Client
-#     include HTTParty
-#     base_uri ClarifaiRuby.configuration.api_url
-#
-#     def initialize
-#       #get access token with client_id and client_secret & put access token in header
-#       @token = Token.new
-#     end
-#
-#     def info(opts)
-#       # Info.new(opts)
-#     end
-#
-#     def tag(opts)
-#       # Tag.new(opts)
-#     end
-#
-#     def feedback(opts)
-#       # Feedback.new(opts)
-#     end
-#
-#     def color(opts)
-#       # Color.new(opts)
-#     end
-#   end
-# end
+module ClarifaiRuby
+  class Client
+    include HTTParty
+    base_uri 'https://api.clarifai.com'
+
+    def initialize
+      #get access token with client_id and client_secret & put access token in header
+      @token = Token.new.token
+      @options = {
+        :headers => {
+          "Authorization" => "Bearer #{@token}"
+        }
+      }
+    end
+
+    def info
+      info_request = InfoRequest.new(@options)
+      info_response = InfoResponse.new(info_request.get)
+      # Info.new(opts)
+    end
+
+    def tag(opts)
+      # Tag.new(opts)
+    end
+
+    def feedback(opts)
+      # Feedback.new(opts)
+    end
+
+    def color(opts)
+      # Color.new(opts)
+    end
+  end
+end
 
 # module ClarifaiRuby
 #   class TagRequest
@@ -65,7 +72,6 @@ module ClarifaiRuby
     def initialize(options)
       @options = options
       @request_path = '/info'
-      @token = Token.new.token
     end
 
     def get_request_url
@@ -74,11 +80,7 @@ module ClarifaiRuby
 
     def get
       #do the actual GET
-      response = self.class.get(build_request_url,
-        :headers => {
-          "Authorization" => "Bearer #{@token}"
-        }
-      )
+      response = self.class.get(build_request_url, :headers => @options[:headers])
     end
     #
     # def post

--- a/lib/clarifai_ruby/configuration.rb
+++ b/lib/clarifai_ruby/configuration.rb
@@ -1,6 +1,6 @@
 module ClarifaiRuby
   class Configuration
-    attr_accessor :base_url, :client_id, :client_secret, :version_path, :token
+    attr_accessor :base_url, :client_id, :client_secret, :version_path
 
     def initialize
       @base_url = 'https://api.clarifai.com'

--- a/lib/clarifai_ruby/configuration.rb
+++ b/lib/clarifai_ruby/configuration.rb
@@ -1,6 +1,6 @@
 module ClarifaiRuby
   class Configuration
-    attr_accessor :base_url, :client_id, :client_secret, :version_path
+    attr_accessor :base_url, :client_id, :client_secret, :version_path, :token
 
     def initialize
       @base_url = "https://api.clarifai.com"

--- a/lib/clarifai_ruby/configuration.rb
+++ b/lib/clarifai_ruby/configuration.rb
@@ -3,8 +3,8 @@ module ClarifaiRuby
     attr_accessor :base_url, :client_id, :client_secret, :version_path, :token
 
     def initialize
-      @base_url = "https://api.clarifai.com"
-      @version_path = "/v1"
+      @base_url = 'https://api.clarifai.com'
+      @version_path = '/v1'
     end
 
     def api_url

--- a/lib/clarifai_ruby/info_request.rb
+++ b/lib/clarifai_ruby/info_request.rb
@@ -1,0 +1,16 @@
+module ClarifaiRuby
+  class InfoRequest
+    INFO_PATH = '/info'
+    attr_reader :raw_response, :options
+
+    def initialize(opts = {})
+      @options = opts
+      @client = Client.new
+    end
+
+    def get
+      @raw_response = @client.get(INFO_PATH, options).parsed_response
+      InfoResponse.new(raw_response)
+    end
+  end
+end

--- a/lib/clarifai_ruby/info_request.rb
+++ b/lib/clarifai_ruby/info_request.rb
@@ -3,13 +3,12 @@ module ClarifaiRuby
     INFO_PATH = '/info'
     attr_reader :raw_response, :options
 
-    def initialize(opts = {})
-      @options = opts
+    def initialize
       @client = Client.new
     end
 
-    def get
-      @raw_response = @client.get(INFO_PATH, options).parsed_response
+    def get(opts = {})
+      @raw_response = @client.get(INFO_PATH, opts).parsed_response
       InfoResponse.new(raw_response)
     end
   end

--- a/lib/clarifai_ruby/info_response.rb
+++ b/lib/clarifai_ruby/info_response.rb
@@ -1,0 +1,16 @@
+module ClarifaiRuby
+  class InfoResponse
+
+    def initialize(json_response, recursion=0)
+      #parse the json response and make each key available
+      json_response.each do |name, value|
+        if value.is_a? Hash
+          initialize(value, recursion+1)
+        else
+          self.class.send(:attr_reader, name)
+          instance_variable_set("@#{name}", value)
+        end
+      end
+    end
+  end
+end

--- a/lib/clarifai_ruby/token.rb
+++ b/lib/clarifai_ruby/token.rb
@@ -1,0 +1,29 @@
+module ClarifaiRuby
+  class Token
+    include HTTParty
+    TOKEN_PATH = "/token"
+
+    def initialize
+      self.class.base_uri ClarifaiRuby.configuration.api_url
+    end
+
+    def token
+      @token ||= generate_token
+    end
+
+    private
+
+    def generate_token
+      body = {
+        "grant_type" => "client_credentials",
+        "client_id" => "#{ClarifaiRuby.configuration.client_id}",
+        "client_secret" => "#{ClarifaiRuby.configuration.client_secret}"
+      }
+
+      response = self.class.post(TOKEN_PATH, :body => body).parsed_response
+      #TODO handle error case here
+      response['access_token']
+    end
+
+  end
+end

--- a/spec/cassettes/ClarifaiRuby_Client/_initialize/gets_a_new_token.yml
+++ b/spec/cassettes/ClarifaiRuby_Client/_initialize/gets_a_new_token.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.clarifai.com/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=-GMMA7LUQQ_xKYRWQDgIosC2U6JNusO7R7neDIJy&client_secret=VPH8lyZjE9BhnztcvXeGWRA_OUEfckFBt4sgWqXj
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Feb 2016 07:52:58 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.1.19
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '152'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token": "brjndBJuMuTEhoQ8geMX4vzyy2cBds", "token_type": "Bearer",
+        "expires_in": 176400, "scope": "api_access_write api_access api_access_read"}'
+    http_version: 
+  recorded_at: Tue, 09 Feb 2016 07:52:58 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ClarifaiRuby_Client/_initialize/sets_the_base_uri_according_to_the_configuration.yml
+++ b/spec/cassettes/ClarifaiRuby_Client/_initialize/sets_the_base_uri_according_to_the_configuration.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.clarifai.com/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=-GMMA7LUQQ_xKYRWQDgIosC2U6JNusO7R7neDIJy&client_secret=VPH8lyZjE9BhnztcvXeGWRA_OUEfckFBt4sgWqXj
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Feb 2016 07:52:57 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.1.19
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '152'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token": "YVnJmrvqltlsWz8LyANyLKaCTGUC3h", "token_type": "Bearer",
+        "expires_in": 176400, "scope": "api_access_write api_access api_access_read"}'
+    http_version: 
+  recorded_at: Tue, 09 Feb 2016 07:52:57 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ClarifaiRuby_InfoRequest/_get/gets_the_raw_response.yml
+++ b/spec/cassettes/ClarifaiRuby_InfoRequest/_get/gets_the_raw_response.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.clarifai.com/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=-GMMA7LUQQ_xKYRWQDgIosC2U6JNusO7R7neDIJy&client_secret=VPH8lyZjE9BhnztcvXeGWRA_OUEfckFBt4sgWqXj
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Feb 2016 07:53:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.1.19
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '152'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token": "IIBAlfK4067z065JzcZ1qtVnLyxHpQ", "token_type": "Bearer",
+        "expires_in": 176400, "scope": "api_access_write api_access api_access_read"}'
+    http_version: 
+  recorded_at: Tue, 09 Feb 2016 07:53:00 GMT
+- request:
+    method: get
+    uri: https://api.clarifai.com/v1/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer IIBAlfK4067z065JzcZ1qtVnLyxHpQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Feb 2016 07:53:00 GMT
+      Server:
+      - nginx/1.1.19
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '413'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status_code": "OK", "status_msg": "All images in request have completed
+        successfully. ", "results": {"max_image_size": 100000, "default_language":
+        "en", "max_video_size": 100000, "max_image_bytes": 10485760, "min_image_size":
+        1, "default_model": "general-v1.3", "max_video_bytes": 104857600, "max_video_duration":
+        1800, "max_batch_size": 128, "max_video_batch_size": 1, "min_video_size":
+        1, "api_version": 0.1}}'
+    http_version: 
+  recorded_at: Tue, 09 Feb 2016 07:53:00 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ClarifaiRuby_InfoRequest/_get/returns_an_info_response_object.yml
+++ b/spec/cassettes/ClarifaiRuby_InfoRequest/_get/returns_an_info_response_object.yml
@@ -1,0 +1,83 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.clarifai.com/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=-GMMA7LUQQ_xKYRWQDgIosC2U6JNusO7R7neDIJy&client_secret=VPH8lyZjE9BhnztcvXeGWRA_OUEfckFBt4sgWqXj
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Feb 2016 07:53:01 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.1.19
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '152'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token": "BEfJAwL52r4vUaOXFYPsw1D8DBq1CL", "token_type": "Bearer",
+        "expires_in": 176400, "scope": "api_access_write api_access api_access_read"}'
+    http_version: 
+  recorded_at: Tue, 09 Feb 2016 07:53:01 GMT
+- request:
+    method: get
+    uri: https://api.clarifai.com/v1/info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer BEfJAwL52r4vUaOXFYPsw1D8DBq1CL
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Feb 2016 07:53:01 GMT
+      Server:
+      - nginx/1.1.19
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '413'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"status_code": "OK", "status_msg": "All images in request have completed
+        successfully. ", "results": {"max_image_size": 100000, "default_language":
+        "en", "max_video_size": 100000, "max_image_bytes": 10485760, "min_image_size":
+        1, "default_model": "general-v1.3", "max_video_bytes": 104857600, "max_video_duration":
+        1800, "max_batch_size": 128, "max_video_batch_size": 1, "min_video_size":
+        1, "api_version": 0.1}}'
+    http_version: 
+  recorded_at: Tue, 09 Feb 2016 07:53:01 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ClarifaiRuby_InfoRequest/_initialize/when_there_are_no_options_passed/set_options_equal_to_an_empty_hash.yml
+++ b/spec/cassettes/ClarifaiRuby_InfoRequest/_initialize/when_there_are_no_options_passed/set_options_equal_to_an_empty_hash.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.clarifai.com/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=-GMMA7LUQQ_xKYRWQDgIosC2U6JNusO7R7neDIJy&client_secret=VPH8lyZjE9BhnztcvXeGWRA_OUEfckFBt4sgWqXj
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Feb 2016 07:52:59 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.1.19
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '152'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token": "WM5TzyRgHJ9hf8u2cNLeMl5cwDb7f0", "token_type": "Bearer",
+        "expires_in": 176400, "scope": "api_access_write api_access api_access_read"}'
+    http_version: 
+  recorded_at: Tue, 09 Feb 2016 07:52:59 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/ClarifaiRuby_InfoRequest/_initialize/when_there_are_options_passed/passes_in_opts_correctly.yml
+++ b/spec/cassettes/ClarifaiRuby_InfoRequest/_initialize/when_there_are_options_passed/passes_in_opts_correctly.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.clarifai.com/v1/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&client_id=-GMMA7LUQQ_xKYRWQDgIosC2U6JNusO7R7neDIJy&client_secret=VPH8lyZjE9BhnztcvXeGWRA_OUEfckFBt4sgWqXj
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Allow:
+      - POST, OPTIONS
+      Cache-Control:
+      - no-store
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 09 Feb 2016 07:52:59 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - nginx/1.1.19
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Length:
+      - '152'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token": "ywOqX9F8DCp6Bbj5KrTElVka8waxsB", "token_type": "Bearer",
+        "expires_in": 176400, "scope": "api_access_write api_access api_access_read"}'
+    http_version: 
+  recorded_at: Tue, 09 Feb 2016 07:52:58 GMT
+recorded_with: VCR 3.0.1

--- a/spec/clarifai_ruby/client_spec.rb
+++ b/spec/clarifai_ruby/client_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe ClarifaiRuby::Client do
+  describe "#initialize" do
+    let(:configured_base_uri) { ClarifaiRuby.configuration.api_url }
+
+    it "sets the base_uri according to the configuration", :vcr do
+      expect(described_class.new.class.base_uri).to eq configured_base_uri
+    end
+
+    it "gets a new token", :vcr do
+      expect(described_class.new.token).not_to be nil
+    end
+  end
+
+  describe "#get" do
+    let(:url) { "/foo" }
+    let(:token) { "this is a token" }
+    let(:headers) do
+      {
+        "Authorization" => "Bearer #{token}"
+      }
+    end
+    let(:token_object) { double(token: token) }
+
+    before do
+      allow(ClarifaiRuby::Token).to receive(:new).and_return token_object
+    end
+
+    context "when there is an opts hash given" do
+      let(:opts) do
+        {
+          foo: "bar"
+        }
+      end
+
+      it "sends the request with the given URL" do
+        expect(described_class).to receive(:get).with(url, headers: headers, body: opts).and_return nil
+
+        described_class.new.get(url, opts)
+      end
+    end
+  end
+end

--- a/spec/clarifai_ruby/info_request_spec.rb
+++ b/spec/clarifai_ruby/info_request_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe ClarifaiRuby::InfoRequest do
+  describe "#initialize" do
+    it "generates a new client" do
+      expect(ClarifaiRuby::Client).to receive(:new)
+
+      described_class.new
+    end
+
+    context "when there are options passed" do
+      let(:opts) { { foo: "bar" } }
+
+      it "passes in opts correctly", :vcr do
+        expect(described_class.new(opts).options).to eq opts
+      end
+    end
+
+    context "when there are no options passed" do
+      it "set options equal to an empty hash", :vcr do
+        expect(described_class.new.options).to be_empty
+      end
+    end
+  end
+
+  describe "#get" do
+    let(:info_request) { described_class.new }
+
+    it "gets the raw response", :vcr do
+      info_request.get
+      expect(info_request.raw_response).not_to be nil
+    end
+
+    it "returns an info response object", :vcr do
+      expect(info_request.get).to be_a ClarifaiRuby::InfoResponse
+    end
+  end
+end

--- a/spec/clarifai_ruby/info_request_spec.rb
+++ b/spec/clarifai_ruby/info_request_spec.rb
@@ -7,20 +7,6 @@ describe ClarifaiRuby::InfoRequest do
 
       described_class.new
     end
-
-    context "when there are options passed" do
-      let(:opts) { { foo: "bar" } }
-
-      it "passes in opts correctly", :vcr do
-        expect(described_class.new(opts).options).to eq opts
-      end
-    end
-
-    context "when there are no options passed" do
-      it "set options equal to an empty hash", :vcr do
-        expect(described_class.new.options).to be_empty
-      end
-    end
   end
 
   describe "#get" do
@@ -33,6 +19,41 @@ describe ClarifaiRuby::InfoRequest do
 
     it "returns an info response object", :vcr do
       expect(info_request.get).to be_a ClarifaiRuby::InfoResponse
+    end
+
+    context "when there are options passed" do
+      let(:opts) { { foo: "bar" } }
+      let(:response) { double }
+      let(:raw_response) { double(:raw_response, parsed_response: json_response) }
+      let(:json_response) { double(:json_response) }
+      let(:client) { double(:client) }
+
+      before do
+        allow(ClarifaiRuby::Client).to receive(:new).and_return client
+        allow(client).to receive(:get).with(described_class::INFO_PATH, opts).and_return raw_response
+        allow(ClarifaiRuby::InfoResponse).to receive(:new).with(json_response).and_return response
+      end
+
+      it "passes opts to the get request correctly" do
+        expect(info_request.get(opts)).to eq response
+      end
+    end
+
+    context "when there are no options passed" do
+      let(:response) { double }
+      let(:raw_response) { double(:raw_response, parsed_response: json_response) }
+      let(:json_response) { double(:json_response) }
+      let(:client) { double(:client) }
+
+      before do
+        allow(ClarifaiRuby::Client).to receive(:new).and_return client
+        allow(client).to receive(:get).with(described_class::INFO_PATH, {}).and_return raw_response
+        allow(ClarifaiRuby::InfoResponse).to receive(:new).with(json_response).and_return response
+      end
+
+      it "passes an empty hash to the get request" do
+        expect(info_request.get).to eq response
+      end
     end
   end
 end

--- a/spec/clarifai_ruby/info_response_spec.rb
+++ b/spec/clarifai_ruby/info_response_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe ClarifaiRuby::InfoResponse do
+  describe "#initialize" do
+    let(:results) do
+      {
+        "max_image_size" => 100000,
+        "default_language" => "en",
+        "max_video_size" => 100000,
+        "max_image_bytes" => 10485760,
+        "min_image_size" => 1,
+        "default_model" => "general-v1.3",
+        "max_video_bytes" => 104857600,
+        "max_video_duration" => 1800,
+        "max_batch_size" => 128,
+        "max_video_batch_size" => 1,
+        "min_video_size" => 1,
+        "api_version" => 0.1
+      }
+    end
+    let(:response) do
+      {
+        "status_code" => "OK",
+        "status_msg" => "All images in request have completed successfully. ",
+        "results" => results
+      }
+    end
+
+    it "makes an attr_reader for max_image_size" do
+      expect(described_class.new(response).max_image_size).to eq results['max_image_size']
+    end
+
+    it "makes an attr_reader for default_language" do
+      expect(described_class.new(response).max_image_size).to eq results['max_image_size']
+    end
+
+    it "makes an attr_reader for max_video_size" do
+      expect(described_class.new(response).max_video_size).to eq results['max_video_size']
+    end
+
+    it "makes an attr_reader for max_image_bytes" do
+      expect(described_class.new(response).max_image_bytes).to eq results['max_image_bytes']
+    end
+
+    it "makes an attr_reader for min_image_size" do
+      expect(described_class.new(response).min_image_size).to eq results['min_image_size']
+    end
+
+    it "makes an attr_reader for default_model" do
+      expect(described_class.new(response).default_model).to eq results['default_model']
+    end
+
+    it "makes an attr_reader for max_video_bytes" do
+      expect(described_class.new(response).max_video_bytes).to eq results['max_video_bytes']
+    end
+
+    it "makes an attr_reader for max_video_duration" do
+      expect(described_class.new(response).max_video_duration).to eq results['max_video_duration']
+    end
+
+    it "makes an attr_reader for max_batch_size" do
+      expect(described_class.new(response).max_batch_size).to eq results['max_batch_size']
+    end
+
+    it "makes an attr_reader for max_video_batch_size" do
+      expect(described_class.new(response).max_video_batch_size).to eq results['max_video_batch_size']
+    end
+
+    it "makes an attr_reader for min_video_size" do
+      expect(described_class.new(response).min_video_size).to eq results['min_video_size']
+    end
+
+    it "makes an attr_reader for api_version" do
+      expect(described_class.new(response).max_image_size).to eq results['max_image_size']
+    end
+  end
+end

--- a/spec/clarifai_ruby/token_spec.rb
+++ b/spec/clarifai_ruby/token_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe ClarifaiRuby::Token do
+  describe "#initialize" do
+    let(:configured_base_uri) { ClarifaiRuby.configuration.api_url }
+
+    it "sets the correct base_uri on the class according to the configuration" do
+      expect(described_class.new.class.base_uri).to eq configured_base_uri
+    end
+  end
+
+  describe "#token" do
+    let(:token) { "this_is_an_access_token" }
+    let(:body) do
+      {
+        "grant_type" => "client_credentials",
+        "client_id" => "#{ClarifaiRuby.configuration.client_id}",
+        "client_secret" => "#{ClarifaiRuby.configuration.client_secret}"
+      }
+    end
+
+    let(:token_response) { double(parsed_response: {'access_token' => token}) }
+
+    before do
+      allow(described_class).to receive(:post).with("/token", body: body).and_return token_response
+    end
+
+    it "returns the token" do
+      expect(described_class.new.token).to eq token
+    end
+  end
+end

--- a/spec/clarifai_ruby_spec.rb
+++ b/spec/clarifai_ruby_spec.rb
@@ -1,4 +1,5 @@
-require 'spec_helper'
+require 'clarifai_ruby'
+require 'pry'
 
 describe ClarifaiRuby do
   it 'has a version number' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,15 @@ require 'clarifai_ruby'
 require 'pry'
 require 'vcr'
 
-VCR.configure do |config|
-  config.cassette_library_dir = "spec/vcr_cassettes"
-  config.hook_into :webmock # or :fakeweb
-  config.configure_rspec_metadata!
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end
+
+ClarifaiRuby.configure do |config|
+  config.base_url = 'https://api.clarifai.com'
+  config.version_path = "/v1"
+  config.client_id = "-GMMA7LUQQ_xKYRWQDgIosC2U6JNusO7R7neDIJy"
+  config.client_secret = "VPH8lyZjE9BhnztcvXeGWRA_OUEfckFBt4sgWqXj"
 end


### PR DESCRIPTION
Now, we have `InfoRequest` and `InfoResponse` that will handle the response and request logic of `/info`

Usage:

```
info = InfoRequest.new
reponse = info.get  #=> will return InfoResponse object
```

This PR also adds in `vcr` capabilities.

Note that we will have to address error handling.
