### PR TITLE
remove rake console, use bin/console instead

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,3 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
-
-task :console do
-  exec "irb -r clarifai_ruby -I ./lib"
-end

--- a/bin/console
+++ b/bin/console
@@ -10,5 +10,14 @@ require "clarifai_ruby"
 # require "pry"
 # Pry.start
 
+ClarifaiRuby.configure do |config|
+  config.base_url = 'https://api.clarifai.com'
+  config.version_path = "/v1"
+  config.client_id = "-GMMA7LUQQ_xKYRWQDgIosC2U6JNusO7R7neDIJy"
+  config.client_secret = "VPH8lyZjE9BhnztcvXeGWRA_OUEfckFBt4sgWqXj"
+end
+
+@client = ClarifaiRuby::Client.new
+
 require "irb"
 IRB.start


### PR DESCRIPTION
I didn’t see that this is possible! This gives the ability to have an initialized configuration for the ClarifaiRuby module when you run `bin/console`, so you don’t have to copy paste the configs every time.

So now, run `bin/console` and you'd be able to play around with all our objects right away.

Bonus: I put in a `@client`, so if you want to make http requests directly using our ClarifaiRuby::Client, you can use it!  Example:

```
$ bin/console
rb(main):001:0> @client
=> #<ClarifaiRuby::Client:0x007fefbcca9de8 @token="07dOq1yBQ6CEPkuYi66Wptdw7EqzQJ">
rb(main):002:0> @client.get("/info")
=> #<HTTParty::Response:0x7fbe6a5462f0 parsed_response= ...
```
