### PR TITLE
Increase Test Coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,24 @@ tag_response.tag_images
 tag_response.tag_images.first.tags
 #=> [#<ClarifaiRuby::Tag>, #<ClarifaiRuby::Tag>, ...]
 ```
+A `TagResponse` will contain an array of `TagImage`s and each `TagImage` will contain an array of `Tag`s
+
+### Tag
+A `Tag` represents each tag returned by Clarifai. 
+
+Each `Tag` contains these readers:
+- `word` - the class of the tag
+- `prob` -  (short for probability) indicate how well the model believes the corresponding tag is associated with the input data.
+- `concept_id` - the corresponding concept_id
 
 #### Model
 
-You can pass in the `model` [(more info)](http://newdocs.clarifai.com/guide/tag#models)
+You can also pass in the `model` [(more info)](http://newdocs.clarifai.com/guide/tag#models)
 
 >If you'd like to get tags for an image or video using a different model, you can do so by passing in a `model` parameter. If you omit this parameter, the API will use the default model for your application. You can change this on the applications page.
 
 ```ruby
-tag_response = ClarifaiRuby::TagRequest.new.get("https://samples.clarifai.com/metro-north.jpg", model: "nsfw-v0.1")
+ClarifaiRuby::TagRequest.new.get("https://samples.clarifai.com/metro-north.jpg", model: "nsfw-v0.1")
 #=> #<ClarifaiRuby::TagResponse>
 ```
 As of February here are the valid models:

--- a/lib/clarifai_ruby/client.rb
+++ b/lib/clarifai_ruby/client.rb
@@ -1,4 +1,6 @@
 module ClarifaiRuby
+  class RequestError < StandardError; end
+  
   class Client
     include HTTMultiParty
     debug_output $stderr

--- a/lib/clarifai_ruby/models/tag_image.rb
+++ b/lib/clarifai_ruby/models/tag_image.rb
@@ -6,39 +6,26 @@ module ClarifaiRuby
                 :status_code,
                 :status_msg,
                 :local_id,
-                :tags
+                :tags,
+                :tags_by_words
 
 
-    def initialize(result_doc)
-      @docid = result_doc["docid"]
-      @docid_str = result_doc["docid_str"]
-      @url = result_doc["url"]
-      @status_code = result_doc["status_code"]
-      @status_msg = result_doc["status_msg"]
-      @local_id = result_doc["local_id"]
-      @tags = generate_tags result_doc["result"]["tag"]
-      @tags_by_words = result_doc["result"]["tag"]["classes"]
+    def initialize(response_doc)
+      @docid = response_doc["docid"]
+      @docid_str = response_doc["docid_str"]
+      @url = response_doc["url"]
+      @status_code = response_doc["status_code"]
+      @status_msg = response_doc["status_msg"]
+      @local_id = response_doc["local_id"]
+      @tags = generate_tags response_doc["result"]["tag"]
+      @tags_by_words = response_doc["result"]["tag"]["classes"]
     end
 
     private
 
     def generate_tags(tag_doc)
-      concept_ids = tag_doc["concept_ids"]
-      classes = tag_doc["classes"]
-      probs = tag_doc["probs"]
-
-      tags = []
-      if concept_ids
-        classes.each_with_index do |c, i|
-          tags << Tag.new(c, probs[i], concept_ids[i])
-        end
-      else
-        classes.each_with_index do |c, i|
-          tags << Tag.new(c, probs[i])
-        end
-      end
-
-      tags
+      tags = tag_doc["classes"].zip(tag_doc["probs"], tag_doc["concept_ids"] || [])
+      tags.map{ |tag| Tag.new(*tag) }
     end
   end
 end

--- a/lib/clarifai_ruby/tag_request.rb
+++ b/lib/clarifai_ruby/tag_request.rb
@@ -1,6 +1,4 @@
 module ClarifaiRuby
-  class RequestError < StandardError; end
-
   class TagRequest
     TAG_PATH = '/tag'
     attr_reader :raw_response, :options
@@ -19,7 +17,7 @@ module ClarifaiRuby
 
       @raw_response = @client.get(TAG_PATH, body).parsed_response
       raise RequestError.new @raw_response["status_msg"] if @raw_response["status_code"] != "OK"
-      
+
       TagResponse.new(raw_response)
     end
 

--- a/spec/clarifai_ruby/models/tag_image_spec.rb
+++ b/spec/clarifai_ruby/models/tag_image_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe ClarifaiRuby::TagImage do
+  describe "#initialize" do
+    subject { described_class.new(response_doc) }
+    let(:response_doc) do
+      {
+        "docid" => 1234567,
+        "docid_str" => "abc123",
+        "url" => "http://hogwarts.wiz",
+        "status_code" => "OK",
+        "status_msg" => "OK",
+        "local_id" => "buyfreshandlocal",
+        "result" => {
+          "tag" => {
+            "concept_ids" => [
+              "ai_HLmqFqBf",
+              "ai_fvlBqXZR",
+              "ai_Xxjc3MhT",
+              "ai_6kTjGfF6",
+            ],
+            "classes" => [
+              "train",
+              "railway",
+              "transportation system",
+              "station",
+            ],
+            "probs" => [
+              0.9989112019538879,
+              0.9975532293319702,
+              0.9959157705307007,
+              0.9925730228424072,
+            ]
+          }
+        }
+      }
+    end
+
+    it "sets docid" do
+      expect(subject.docid).to eq response_doc["docid"]
+    end
+
+    it "sets docid_str" do
+      expect(subject.docid_str).to eq response_doc["docid_str"]
+    end
+
+    it "sets url" do
+      expect(subject.url).to eq response_doc["url"]
+    end
+
+    it "sets status_code" do
+      expect(subject.status_code).to eq response_doc["status_code"]
+    end
+
+    it "sets status_msg" do
+      expect(subject.status_msg).to eq response_doc["status_msg"]
+    end
+
+    it "sets local_id" do
+      expect(subject.local_id).to eq response_doc["local_id"]
+    end
+
+    it "sets tags_by_words" do
+      expect(subject.tags_by_words).to eq response_doc["result"]["tag"]["classes"]
+    end
+
+    it "sets tags as Tag objects" do
+      subject.tags.each do |tag|
+        expect(tag).to be_a ClarifaiRuby::Tag
+      end
+    end
+
+    it "sets the correct words" do
+      subject.tags.each_with_index do |tag, i|
+        expect(tag.word).to eq response_doc["result"]["tag"]["classes"][i]
+      end
+    end
+
+    it "sets the correct probs" do
+      subject.tags.each_with_index do |tag, i|
+        expect(tag.prob).to eq response_doc["result"]["tag"]["probs"][i]
+      end
+    end
+
+    it "sets the correct probs" do
+      subject.tags.each_with_index do |tag, i|
+        expect(tag.concept_id).to eq response_doc["result"]["tag"]["concept_ids"][i]
+      end
+    end
+  end
+end

--- a/spec/clarifai_ruby/models/tag_spec.rb
+++ b/spec/clarifai_ruby/models/tag_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe ClarifaiRuby::Tag do
+  describe "#initialize" do
+    let(:word) { "unicorn" }
+    let(:prob) { 0.98 }
+    let(:concept_id) { "ai_unicorn" }
+    
+    subject { described_class.new(word, prob, concept_id) }
+
+    it 'sets word' do
+      expect(subject.word).to eq word
+    end
+
+    it 'sets prob' do
+      expect(subject.prob).to eq prob
+    end
+
+    it 'sets concept_id' do
+      expect(subject.concept_id).to eq concept_id
+    end
+  end
+end


### PR DESCRIPTION
- added specs for Tag and TagImage
- simplified `generate_tags` method in `TagImage` (per technical review comment)
- updated README to include short description of relationship between TagResponse, TagImage and Tag
- moved RequestError to Client file instead

Notes to ourselves:
- need to add specs to `TagRequest` and `TagResponse`
- need to rethink `TagImage#initialize`

addresses https://github.com/chardane/ClarifaiRuby/issues/13
